### PR TITLE
Added setW3cCheckUrl, necessary for when running a copy of the W3C validator locally

### DIFF
--- a/lib/w3cjs.js
+++ b/lib/w3cjs.js
@@ -7,6 +7,10 @@ var defaultCallback = function (res) {
 	console.log(res);
 }
 
+function setW3cCheckUrl(newW3cCheckUrl) {
+	w3cCheckUrl = newW3cCheckUrl;
+}
+
 function validate(options) {
 	var output = options.output || defaultOutput;
 	var callback = options.callback || defaultCallback;
@@ -40,7 +44,8 @@ function validate(options) {
 	});
 }
 var w3cjs = {
-	validate: validate
+	validate: validate,
+	setW3cCheckUrl: setW3cCheckUrl
 }
 if (typeof exports !== 'undefined') {
   if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
You can install and run your own copy of the W3C HTML validator: http://validator.w3.org/docs/install.html. You'll need to be able to set the validator URL to take advantage of this.
