### PR TITLE
Fix license property

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "html",
     "html5"
   ],
-  "license": "http://unlicense.org/"
+  "license": {
+    "type": "Unlicense",
+    "url": "https://raw.github.com/thomasdavis/w3cjs/master/LICENSE"
+  }
 }


### PR DESCRIPTION
The current value causes `undefined` to be shown on the npm registry
