### PR TITLE
add a binary

### DIFF
--- a/bin/w3cjs
+++ b/bin/w3cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+var w3cjs = require('../lib/w3cjs');
+var program = require('commander');
+
+program.version(require('../package.json').version);
+
+program.name = 'w3cjs';
+
+program
+	.command('validate <file>')
+	.description('validate the given file')
+	.action(function (file) {
+		w3cjs
+			.validate({
+				file: file,
+				callback: function (res) {
+					var count = res.messages.length;
+					if (!count) return process.exit(0);
+
+					res.messages.forEach(function (err) {
+						console.error('%s: %s (%d:%d)', err.type.toUpperCase(), err.message, err.lastLine, err.lastColumn);
+					});
+
+					process.exit(count);
+				}
+			});
+	});
+
+program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -8,9 +8,13 @@
     "url": "https://github.com/thomasdavis/w3cjs"
   },
   "main": "./lib/w3cjs",
+  "bin": {
+    "w3cjs": "./bin/w3cjs"
+  },
   "dependencies": {
     "argparse": ">= 0.1.3",
-    "superagent": ">= 0.6.0"
+    "superagent": ">= 0.6.0",
+    "commander": "~2.0.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
enables usage from the cli:

```
$ ./bin/w3cjs validate example/demo.html 
ERROR: Bad value X-UA-Compatible for attribute http-equiv on element meta. (8:64)
ERROR: Element title must not be empty. (9:17)
```
