### PR TITLE
add options to CLI

### DIFF
--- a/bin/w3cjs
+++ b/bin/w3cjs
@@ -8,7 +8,7 @@ program.version(require('../package.json').version);
 program.name = 'w3cjs';
 
 program
-	.command('validate <file>')
+	.command('validate [file]')
 	.option('-c, --check-url [value]', 'Validator URL [http://validator.w3.org/check]')
 	.description('validate the given file')
 	.action(function (file, options) {
@@ -29,9 +29,9 @@ program
 			w3cjs.setW3cCheckUrl(options.checkUrl);
 		}
 
-		if(file === '-') {
+		if(file === undefined || file === '-') {
 			var concat = require('concat-stream');
-			
+
 			process.stdin.pipe(concat(function(data){
 				validatorOpts.input = data;
 				w3cjs.validate(validatorOpts);

--- a/bin/w3cjs
+++ b/bin/w3cjs
@@ -9,8 +9,13 @@ program.name = 'w3cjs';
 
 program
 	.command('validate <file>')
+	.option('-c, --check-url [value]', 'Validator URL [http://validator.w3.org/check]')
 	.description('validate the given file')
-	.action(function (file) {
+	.action(function (file, options) {
+		if(options.checkUrl) {
+			w3cjs.setW3cCheckUrl(options.checkUrl);
+		}
+
 		w3cjs
 			.validate({
 				file: file,

--- a/bin/w3cjs
+++ b/bin/w3cjs
@@ -12,24 +12,35 @@ program
 	.option('-c, --check-url [value]', 'Validator URL [http://validator.w3.org/check]')
 	.description('validate the given file')
 	.action(function (file, options) {
+		var validatorOpts = {
+			callback: function (res) {
+				var count = res.messages.length;
+				if (!count) return process.exit(0);
+
+				res.messages.forEach(function (err) {
+					console.error('%s: %s (%d:%d)', err.type.toUpperCase(), err.message, err.lastLine, err.lastColumn);
+				});
+
+				process.exit(count);
+			}
+		};
+
 		if(options.checkUrl) {
 			w3cjs.setW3cCheckUrl(options.checkUrl);
 		}
 
-		w3cjs
-			.validate({
-				file: file,
-				callback: function (res) {
-					var count = res.messages.length;
-					if (!count) return process.exit(0);
+		if(file === '-') {
+			var concat = require('concat-stream');
+			
+			process.stdin.pipe(concat(function(data){
+				validatorOpts.input = data;
+				w3cjs.validate(validatorOpts);
+			}));
 
-					res.messages.forEach(function (err) {
-						console.error('%s: %s (%d:%d)', err.type.toUpperCase(), err.message, err.lastLine, err.lastColumn);
-					});
-
-					process.exit(count);
-				}
-			});
+		} else {
+			validatorOpts.file = file;
+			w3cjs.validate(validatorOpts);
+		}
 	});
 
 program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "commander": "~2.6.0",
+    "concat-stream": "^1.4.7",
     "superagent": "~0.21.0",
     "superagent-proxy": "^0.3.1"
   },


### PR DESCRIPTION
The PR has two additions to the CLI tool: piping is now possible when '-' is given as the file name.
I also added an option for a custom checker url. I run a [local copy of the validator](http://habilis.net/validator-sac/), so being able to specify a local endpoint it useful.

posible usage: 

```
php -f file.php | w3cjs validate --check-url $url -
```
