### PR TITLE
package.json: Make license a valid SPDX expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "author": "Thomas Davis <thomasalwyndavis@gmail.com>",
   "name": "w3cjs",
   "description": "A node.js module for using the w3c validator.",
+  "license": "Unlicense",
   "version": "0.3.0",
   "repository": {
     "type": "git",
@@ -26,9 +27,5 @@
     "validator",
     "html",
     "html5"
-  ],
-  "license": {
-    "type": "Unlicense",
-    "url": "https://raw.github.com/thomasdavis/w3cjs/master/LICENSE"
-  }
+  ]
 }


### PR DESCRIPTION
This updates the `package.json`'s license field to be a valid
SPDX license expression, avoiding an npm warning.