### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var results = w3cjs.validate({
 });
 ```
 
-## Example async testing with Mocha 
+## Example async testing with Mocha
 
 ```js
 var w3cjs = require('w3cjs');
@@ -39,9 +39,9 @@ describe('html validation', function(){
 	it('index page should have no html errors', function(done){
 		w3cjs.validate({
 			file: 'index.html',
-			callback: function (res) {
-					console.log(res);
-				if (res.messages.length > 0 ) {
+			callback: function (error, res) {
+				console.log(error || res);
+				if (res && res.messages.length > 0 ) {
 					throw {error: 'html errors have been found', results: res};
 				};
 				done();

--- a/example/index.js
+++ b/example/index.js
@@ -7,8 +7,8 @@ var results = w3cjs.validate({
 	// input: myBuffer,
 	output: 'json', // Defaults to 'json', other option includes html
 	// proxy: 'http://proxy:8080', // Default to null
-	callback: function (res) {
-		console.log(res);
+	callback: function (error, res) {
+		console.log(error || res);
 		// depending on the output type, res will either be a json object or a html string
 	}
 });

--- a/lib/w3cjs.js
+++ b/lib/w3cjs.js
@@ -49,28 +49,30 @@ function validate(options) {
 		req.query({ out: output });
 		req.send((type === 'local') ? fs.readFileSync(file, 'utf8') : input + "");
 	};
-	req.end(function(res){
-		if(output === 'json'){
+	req.end(function(error, res){
+		if(error) {
+			callback(error);
+		} else if(output === 'json'){
 			res.body.context = context;
-			callback(res.body);
+			callback(null, res.body);
 		} else {
-			callback(res.text);
+			callback(null, res.text);
 		}
 	});
 }
 
 var getRequest = function(isLocal, options) {
-   var req = isLocal ? proxyRequest.post(w3cCheckUrl) : proxyRequest.get(w3cCheckUrl);
+	var req = isLocal ? proxyRequest.post(w3cCheckUrl) : proxyRequest.get(w3cCheckUrl);
 
-   var proxy = options.proxy || defaultProxy;
-   if (proxy !== null) {
-      req.proxy(proxy);
-   }
+	var proxy = options.proxy || defaultProxy;
+	if (proxy !== null) {
+		req.proxy(proxy);
+	}
 
-   req.set('User-Agent', 'w3cjs - npm module');
-   req.set('Content-Type', 'text/html; encoding=utf-8');
+	req.set('User-Agent', 'w3cjs - npm module');
+	req.set('Content-Type', 'text/html; encoding=utf-8');
 
-   return req;
+	return req;
 }
 
 var w3cjs = {
@@ -78,10 +80,10 @@ var w3cjs = {
 	setW3cCheckUrl: setW3cCheckUrl
 }
 if (typeof exports !== 'undefined') {
-  if (typeof module !== 'undefined' && module.exports) {
+	if (typeof module !== 'undefined' && module.exports) {
 	exports = module.exports = w3cjs;
-  }
-  exports.w3cjs = w3cjs
+	}
+	exports.w3cjs = w3cjs
 } else {
-  root['w3cjs'] = w3cjs;
+	root['w3cjs'] = w3cjs;
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "w3cjs": "./bin/w3cjs"
   },
   "dependencies": {
-    "commander": "~2.6.0",
-    "superagent": "~0.21.0",
-    "superagent-proxy": "^0.3.1"
+    "commander": "^2.9.0",
+    "superagent": "^3.5.2",
+    "superagent-proxy": "^1.0.2"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
This updates the dependencies to their latest versions and due to
the changes in them, adds an error argument to the callback, which
is also in line with the error-first convention of callbacks.

**Changes:**

- Updated dependencies to their latest versions
  - commander 2.6.0 -> 2.9.0
  - superagent 0.21.0 -> 3.5.2
  - superagent-proxy 0.3.1 -> 1.0.2
- Updated README to reflect change in API
- Updated example.js to handle the error argument